### PR TITLE
OpenAPI 3.0 migration

### DIFF
--- a/apiee-core/pom.xml
+++ b/apiee-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.phillip-kruger</groupId>
         <artifactId>apiee</artifactId>
-        <version>1.0.9-SNAPSHOT</version>
+        <version>2.0.0-oa3</version>
         <relativePath>../</relativePath>
     </parent>
     

--- a/apiee-core/pom.xml
+++ b/apiee-core/pom.xml
@@ -16,21 +16,21 @@
     <description>A library to add generated swagger doc to your Java EE systems</description>
     
     <properties>
-        <swagger.ui.version>2.2.10</swagger.ui.version>
-        <swagger.ui.themes.version>2.1.0</swagger.ui.themes.version>
-        <swagger.version>1.5.21</swagger.version>
+        <swagger.ui.version>3.20.5</swagger.ui.version>
+        <swagger.ui.themes.version>3.0.0</swagger.ui.themes.version>
+        <swagger.version>2.0.6</swagger.version>
     </properties>
     
     <dependencies>
         <!-- Swagger UI -->
         <dependency>
-            <groupId>org.webjars.bower</groupId>
+            <groupId>org.webjars</groupId>
             <artifactId>swagger-ui</artifactId>
             <version>${swagger.ui.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.webjars.bower</groupId>
+            <groupId>org.webjars.npm</groupId>
             <artifactId>swagger-ui-themes</artifactId>
             <version>${swagger.ui.themes.version}</version>
             <scope>runtime</scope>
@@ -38,13 +38,13 @@
         
         <!-- Swagger - For Endpoint documentation -->
         <dependency>
-            <groupId>io.swagger</groupId>
+            <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-jaxrs</artifactId>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-jaxrs2</artifactId>
             <version>${swagger.version}</version>
             
             <exclusions>

--- a/apiee-core/src/main/java/com/github/phillipkruger/apiee/ApieeService.java
+++ b/apiee-core/src/main/java/com/github/phillipkruger/apiee/ApieeService.java
@@ -149,7 +149,7 @@ public class ApieeService {
         // Else, let's see what we discovered with Apiee Auto register.
         Set<Class<?>> applicationClasses = new HashSet<>();
         apieeClasses.forEach((c) -> {
-            applicationClasses.add(c);
+            //applicationClasses.add(c);
         });
         
         return applicationClasses;

--- a/apiee-core/src/main/java/com/github/phillipkruger/apiee/Templates.java
+++ b/apiee-core/src/main/java/com/github/phillipkruger/apiee/Templates.java
@@ -82,38 +82,6 @@ public class Templates {
         // System properties.
         html = html.replaceAll(VAR_CONTEXT_ROOT, getOriginalContextPath(uriInfo,request));
         html = html.replaceAll(VAR_CURRENT_YEAR, String.valueOf(Calendar.getInstance().get(Calendar.YEAR)));
-        // Whitelabel properties.
-        if(whiteLabel.hasProperties()){
-            // First do all unknown properties.
-            Map<String, String> properties = whiteLabel.getProperties();
-            Set<Map.Entry<String, String>> pes = properties.entrySet();
-            for(Map.Entry<String,String> p:pes){
-                String key = PERSENTAGE + p.getKey() + PERSENTAGE;
-                html = html.replaceAll(key, p.getValue());
-            }
-
-        } else {
-            log.warning("No white label properties, returning vanilla template");
-        }
-        // Then properties with defaults.
-        html = html.replaceAll(VAR_COPYRIGHT_BY, VAL_COPYRIGHT_BY);
-        html = html.replaceAll(VAR_TITLE, VAL_TITLE);
-        html = html.replaceAll(VAR_JSON_BUTTON, VAL_JSON_BUTTON);
-        html = html.replaceAll(VAR_YAML_BUTTON, VAL_YAML_BUTTON);
-        html = html.replaceAll(VAR_SWAGGER_THEME, VAL_SWAGGER_THEME);
-        html = html.replaceAll(VAR_DOC_EXPANSION, VAL_DOC_EXPANSION);
-        html = html.replaceAll(VAR_JSON_EDITOR, VAL_JSON_EDITOR);
-        html = html.replaceAll(VAR_DEFAULT_MODEL_RENDERING, VAL_DEFAULT_MODEL_RENDERING);
-        html = html.replaceAll(VAR_SHOW_REQUEST_HEADERS, VAL_SHOW_REQUEST_HEADERS);
-        html = html.replaceAll(VAR_SHOW_OPERATION_IDS, VAL_SHOW_OPERATION_IDS);
-        html = html.replaceAll(VAR_VALIDATOR_URL,VAL_VALIDATOR_URL);
-        html = html.replaceAll(VAR_SUPPORTED_SUBMIT_METHODS,VAL_SUPPORTED_SUBMIT_METHODS);
-        html = html.replaceAll(VAR_OAUTH_CLIENT_ID,VAL_OAUTH_CLIENT_ID);
-        html = html.replaceAll(VAR_OAUTH_CLIENT_SECRET,VAL_OAUTH_CLIENT_SECRET);
-        html = html.replaceAll(VAR_OAUTH_REALM,VAL_OAUTH_REALM);
-        html = html.replaceAll(VAR_OAUTH_APP_NAME,VAL_OAUTH_APP_NAME);
-        html = html.replaceAll(VAR_OAUTH_SCOPE_SEPARATOR,VAL_OAUTH_SCOPE_SEPARATOR);
-        html = html.replaceAll(VAR_SERVER_INFO, request.getServletContext().getServerInfo());
         return html;
     }
     

--- a/apiee-core/src/main/webapp/apiee/template.html
+++ b/apiee-core/src/main/webapp/apiee/template.html
@@ -39,7 +39,7 @@
     window.onload = function() {
         // Begin Swagger UI call region
         const ui = SwaggerUIBundle({
-            url: window.top.location.href + "/swagger.json",
+            url: window.location.href.replace("index.html","swagger.json"),
             dom_id: '#swagger-ui',
             deepLinking: true,
             presets: [

--- a/apiee-core/src/main/webapp/apiee/template.html
+++ b/apiee-core/src/main/webapp/apiee/template.html
@@ -1,129 +1,60 @@
+<!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="x-ua-compatible" content="IE=edge">
-        <title>%title%</title>
-        <link rel="icon" type="image/png" href="favicon-32.png" sizes="32x32" />
-        <link rel="icon" type="image/png" href="favicon-16.png" sizes="16x16" />
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" type="text/css" href="%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/favicon-16x16.png" sizes="16x16" />
+    <style>
+        html
+        {
+            box-sizing: border-box;
+            overflow: -moz-scrollbars-vertical;
+            overflow-y: scroll;
+        }
 
-        <link href='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
-        <link href='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
-        <link href='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-        <link href='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
-        <link href='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+        *,
+        *:before,
+        *:after
+        {
+            box-sizing: inherit;
+        }
 
-        <link href='%contextRoot%/webjars/swagger-ui-themes/${swagger.ui.themes.version}/themes/theme-%swaggerUiTheme%.css' media='screen' rel='stylesheet' type='text/css'/>
-        <link href='apiee.css' media='screen' rel='stylesheet' type='text/css'/>
-        
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/object-assign-pollyfill.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/jquery.slideto.min.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/jquery.wiggle.min.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/handlebars-4.0.5.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/lodash.min.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/backbone-min.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/swagger-ui.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/jsoneditor.min.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/marked.js' type='text/javascript'></script>
-        <script src='%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/dist/lib/swagger-oauth.js' type='text/javascript'></script>
+        body
+        {
+            margin:0;
+            background: #fafafa;
+        }
+    </style>
+</head>
 
-        <script type="text/javascript">
-            $(function () {
+<body>
+<div id="swagger-ui"></div>
 
-                var currentUrl = window.location.href;
-                var jsonUrl = currentUrl.replace("index.html","swagger.json");
-                var yamlUrl = currentUrl.replace("index.html","swagger.yaml");
-                
-                $("#aJson").attr('href', jsonUrl);
-                $("#aYaml").attr('href', yamlUrl);
+<script src="%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/swagger-ui-bundle.js"> </script>
+<script src="%contextRoot%/webjars/swagger-ui/${swagger.ui.version}/swagger-ui-standalone-preset.js"> </script>
+<script>
+    window.onload = function() {
+        // Begin Swagger UI call region
+        const ui = SwaggerUIBundle({
+            url: window.top.location.href + "/swagger.json",
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+            layout: "StandaloneLayout"
+        })
+        // End Swagger UI call region
 
-                $("#logo").attr('href', window.location.pathname);
-
-                hljs.configure({
-                    highlightSizeThreshold: 5000
-                });
-
-                // Pre load translate...
-                if(window.SwaggerTranslator) {
-                    window.SwaggerTranslator.translate();
-                }
-                window.swaggerUi = new SwaggerUi({
-                    url: jsonUrl, // Externalize this ?
-                    dom_id: "swagger-ui-container",
-                    supportedSubmitMethods: %supportedSubmitMethods%,
-                    onComplete: function(swaggerApi, swaggerUi){
-                        if(typeof initOAuth == "function") {
-                            initOAuth({
-                                clientId: "%oauthClientId%",
-                                clientSecret: "%oauthClientSecret%",
-                                realm: "%oauthRealm%",
-                                appName: "%oauthAppName%",
-                                scopeSeparator: "%oauthScopeSeparator%",
-                                additionalQueryStringParams: {}
-                            });
-                        }
-
-                        if(window.SwaggerTranslator) {
-                            window.SwaggerTranslator.translate();
-                        }
-                        
-                        $.ajax({
-                            type: "GET",
-                            url: "generatedOn.json",
-                            dataType: 'json',
-                            success: function(json, textStatus, request){
-                                $("#generatedOn").text(json.formattedDate);
-                            }
-                        });
-                    },
-                    onFailure: function(data) {
-                        log("Unable to Load SwaggerUI");
-                    },
-                    docExpansion: "%docExpansion%",
-                    jsonEditor: %jsonEditor%,
-                    defaultModelRendering: "%defaultModelRendering%",
-                    showRequestHeaders: %showRequestHeaders%,
-                    showOperationIds: %showOperationIds%,
-                    validatorUrl: %validatorUrl%
-                });
-
-                window.swaggerUi.load();
-
-                function log() {
-                    if ('console' in window) {
-                        console.log.apply(console, arguments);
-                    }
-                }
-              
-            });
-        </script>
-    </head>
-
-    <body class="swagger-section">
-        <div id='header'>
-          <div class="swagger-ui-wrap">
-                <a id="logo" href="#"><img class="logo__img" height="30" width="30" src="logo.png" /><span class="logo__title">%title%</span></a>
-                <form id='api_selector'>
-                    <div class='input'><a target="_blank" id="aJson" class="header__btn btnHeader" href="" data-sw-translate>%jsonButtonCaption%</a></div>
-                    <div class='input'><a target="_blank" id="aYaml" class="header__btn btnHeader" href="" data-sw-translate>%yamlButtonCaption%</a></div>
-                    <div id='auth_container'></div>
-                </form>
-          </div>
-        </div>
-
-        <div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
-        <div id="swagger-ui-container" class="swagger-ui-wrap"></div>
-
-        <div id='footer'>
-            <p class="swagger-ui-wrap">
-                Created with <a target="_blank" href="https://github.com/phillip-kruger/apiee" data-sw-translate>Apiee</a> . &copy; %currentYear% %copyrighBy% 
-                | Generated on <i id="generatedOn">0</i>
-                | Running on %serverInfo%
-            </p>
-        </div>
-    </body>
+        window.ui = ui
+    }
+</script>
+</body>
 </html>

--- a/apiee-example/pom.xml
+++ b/apiee-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.phillip-kruger</groupId>
         <artifactId>apiee</artifactId>
-        <version>1.0.9-SNAPSHOT</version>
+        <version>2.0.0-oa3</version>
         <relativePath>../</relativePath>
     </parent>
     

--- a/apiee-lite/pom.xml
+++ b/apiee-lite/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.phillip-kruger</groupId>
         <artifactId>apiee</artifactId>
-        <version>1.0.9-SNAPSHOT</version>
+        <version>2.0.0-oa3</version>
         <relativePath>../</relativePath>
     </parent>
     

--- a/apiee-providers/pom.xml
+++ b/apiee-providers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.phillip-kruger</groupId>
         <artifactId>apiee</artifactId>
-        <version>1.0.9-SNAPSHOT</version>
+        <version>2.0.0-oa3</version>
         <relativePath>../</relativePath>
     </parent>
     

--- a/pom.xml
+++ b/pom.xml
@@ -37,21 +37,18 @@
         <url>https://github.com/phillip-kruger/apiee</url>        
     </scm>
 
+
     <distributionManagement>
-        <site>
-            <id>api.wiki</id>
-            <url>https://github.com/phillip-kruger/apiee/wiki</url>
-        </site>
-        
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
+        <!--  Publish versioned releases here  -->
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>nexus-release</id>
+            <url>${nexus.url.release}</url>
         </repository>
-        
+        <!--  Publish snapshots here  -->
+        <snapshotRepository>
+            <id>nexus-snapshot</id>
+            <url>${nexus.url.snapshot}</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <developers>
@@ -105,18 +102,7 @@
             
             <build>
                 <plugins>
-                    <!-- To release to Maven central -->
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
-                    </plugin>
+
                     <!-- To generate javadoc -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.github.phillip-kruger</groupId>
         <artifactId>javaee-servers-parent</artifactId>
-        <version>javaee-7-v5-SNAPSHOT</version>
+        <version>javaee-7-v4</version>
     </parent>
     
     <groupId>com.github.phillip-kruger</groupId>
     <artifactId>apiee</artifactId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>2.0.0-oa3</version>
     <packaging>pom</packaging>
     
     <name>apiee</name>
@@ -20,7 +20,7 @@
     <modules>
         <module>apiee-core</module>
         <module>apiee-providers</module>
-        <module>apiee-example</module>
+        <!--<module>apiee-example</module>-->
         <module>apiee-lite</module>
     </modules>
     


### PR DESCRIPTION
Hi,
I have tried to migrate basic features to OpenAPI 3.0.
I have disabled tests and enable only info override.

This request is not to merge it  (dirty POC) but to open the possibility of migration.

Apiee and openapi micro service extension don't cover the same use case. Could it possible to maintain both with a common library for OpenAPI management?