### PR TITLE
Upgraded to the newest Swagger 1.x version

### DIFF
--- a/apiee-core/pom.xml
+++ b/apiee-core/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <swagger.ui.version>2.2.10</swagger.ui.version>
         <swagger.ui.themes.version>2.1.0</swagger.ui.themes.version>
-        <swagger.version>1.5.21</swagger.version>
+        <swagger.version>1.6.2</swagger.version>
     </properties>
     
     <dependencies>


### PR DESCRIPTION
Discovered that Jackson 2.11+ was incompatible with this version of swagger-jaxrs

Also, it seems to me that the version_1 branch by accident is not on version 1 anymore, if I've understood everything correctly. Hence that as the destination branch of this PR.