### PR TITLE
Update swagger versions

### DIFF
--- a/apiee-core/pom.xml
+++ b/apiee-core/pom.xml
@@ -16,9 +16,9 @@
     <description>A library to add generated swagger doc to your Java EE systems</description>
     
     <properties>
-        <swagger.ui.version>3.23.11</swagger.ui.version>
+        <swagger.ui.version>5.18.3</swagger.ui.version>
         <swagger.ui.themes.version>3.0.0</swagger.ui.themes.version>
-        <swagger.version>2.2.19</swagger.version>
+        <swagger.version>2.2.28</swagger.version>
     </properties>
     
     <dependencies>
@@ -46,17 +46,6 @@
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-jaxrs2-jakarta</artifactId>
             <version>${swagger.version}</version>
-            
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.validation</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Update to latest Swagger.ui.version 5.18.3 and Swagger.version 2.2.28. 

Javax exclusions are no longer needed for swagger-jaxrs2-jakarta dependency.

Tested on Wildfly 34
